### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
 		<version.common.lang>2.6</version.common.lang>
 		<version.java.source>1.7</version.java.source>
 		<version.java.target>1.7</version.java.target>
-		<version.commons.collections>3.2.1</version.commons.collections>
+		<version.commons.collections>3.2.2</version.commons.collections>
 		<version.commons.pool>1.5.5</version.commons.pool>
 		<version.c3p0>0.9.5.1</version.c3p0>
 		<version.bonecp>0.7.1.RELEASE</version.bonecp>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/